### PR TITLE
Add community-content folder and update project structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,21 @@ The documentation will be available at `http://localhost:3000`
 
 ```
 requestly-docs/
-├── changelogs/          # Release notes and changelogs
-├── general/             # General documentation
-│   ├── getting-started/ # Getting started guides
-│   ├── api-client/      # API Client documentation
-│   ├── http-rules/      # HTTP Rules guides
-│   ├── mock-server/     # Mock Server documentation
-│   ├── sessions/        # Session recording docs
-│   └── team/            # Team & collaboration features
-├── guides/              # How-to guides and tutorials
-├── public-apis/         # Public API documentation
-├── troubleshoot/        # Troubleshooting guides
-├── images/              # Image assets
-├── docs.json            # Mintlify configuration
-└── LICENSE              # License file
+├── changelogs/              # Release notes and changelogs
+├── community-content/       # Community-driven guides and examples
+├── general/                 # General documentation
+│   ├── getting-started/     # Getting started guides
+│   ├── api-client/          # API Client documentation
+│   ├── http-rules/          # HTTP Rules guides
+│   ├── mock-server/         # Mock Server documentation
+│   ├── sessions/            # Session recording docs
+│   └── team/                # Team & collaboration features
+├── guides/                  # How-to guides and tutorials
+├── images/                  # Image assets
+├── public-apis/             # Public API documentation
+├── troubleshoot/            # Troubleshooting guides
+├── docs.json                # Mintlify configuration
+└── LICENSE                  # License file
 ```
 
 ## 📝 Contributing


### PR DESCRIPTION
The documentation references a *Community Content* section, but the folder was missing both in the repository and in the project structure tree in the README.
This PR adds the missing `community-content/` directory and updates the project structure block accordingly.

### **What was changed**

* Added a new folder to the repo:

  ```
  community-content/
  ```

  (Currently empty and ready for community-driven guides.)

* Updated the Project Structure block to include:

  ```
  community-content/   # Community-driven guides and examples
  ```

### **Why this change matters**

Developers browsing the repo rely on both the repository structure and the README tree to understand how content is organized.
Adding the actual folder prevents dead references and makes it easier for contributors to locate where community guide submissions should go.