### PR TITLE
Add Vault docs and sweep em dashes from docs

### DIFF
--- a/account/blocklist.mdx
+++ b/account/blocklist.mdx
@@ -3,7 +3,7 @@ title: Blocklist
 label: Blocklist
 slug: blocklist
 description: Blocklist allows you to disable Requestly Extension for certain websites.
-seoTitle: Blocklist — Stop Requestly on selected websites
+seoTitle: "Blocklist: Stop Requestly on selected websites"
 seoDescription: >-
   The blocklist feature of Requestly allows you to disable Requestly for
   selected websites. This helps in disabling Requestly on websites you don’t

--- a/api-client/design-apis.mdx
+++ b/api-client/design-apis.mdx
@@ -95,7 +95,7 @@ This flexibility ensures you can quickly set up your API workspace without start
 
 ## Variables in APIs
 
-Requestly supports variables in two forms — **Collection Variables** and **Environment Variables**. Variables simplify managing repetitive or shared parts of APIs, such as base URLs or API keys. For example, multiple APIs can share the same base URL or authentication token.
+Requestly supports variables in two forms, **Collection Variables** and **Environment Variables**. Variables simplify managing repetitive or shared parts of APIs, such as base URLs or API keys. For example, multiple APIs can share the same base URL or authentication token.
 
 Variables can be defined in environments and used in API requests by enclosing them in double curly braces, e.g., `{{base_url}}`.
 

--- a/api-client/environments-and-variables.mdx
+++ b/api-client/environments-and-variables.mdx
@@ -5,7 +5,7 @@ slug: environments-and-variables
 description: 'Learn how to use variables and environments in Requestly to manage dynamic values like API keys, base URLs, and tokens across your API requests.'
 visibility: PUBLIC
 ---
-Variables in Requestly’s API Client let you store and reuse dynamic values—like API keys, base URLs, and user IDs—across your API requests. They help you avoid hardcoding, make your collections more modular, and simplify switching between different environments like development, staging, and production.
+Variables in Requestly’s API Client let you store and reuse dynamic values, like API keys, base URLs, and user IDs, across your API requests. They help you avoid hardcoding, make your collections more modular, and simplify switching between different environments like development, staging, and production.
 
 A **variable** is a named placeholder you define once and reference anywhere in your API collections using the `{{variable_name}}` syntax.
 

--- a/api-client/environments-and-variables/collection-and-subcollection-variables.mdx
+++ b/api-client/environments-and-variables/collection-and-subcollection-variables.mdx
@@ -6,7 +6,7 @@ visibility: "PUBLIC"
 format: "MDX"
 ---
 
-**Collection** and **SubCollection Variables** in Requestly let you define scoped values that are only available within a specific collection or a nested sub-group of requests. These variables are ideal when you want to manage shared data for a group of related requests—without affecting global or environment-level variables.
+**Collection** and **SubCollection Variables** in Requestly let you define scoped values that are only available within a specific collection or a nested sub-group of requests. These variables are ideal when you want to manage shared data for a group of related requests, without affecting global or environment-level variables.
 
 They help you build modular, reusable collections and make it easy to organize values related to a particular service, API module, or test scenario.
 

--- a/api-client/environments-and-variables/environment-variables.mdx
+++ b/api-client/environments-and-variables/environment-variables.mdx
@@ -6,7 +6,7 @@ visibility: "PUBLIC"
 format: "MDX"
 ---
 
-**Environment Variables** in Requestly allow you to configure API requests based on different environments—such as **Development**, **Staging**, or **Production**. They help you manage environment-specific values like base URLs, tokens, or credentials without manually editing each request when switching contexts.
+**Environment Variables** in Requestly allow you to configure API requests based on different environments, such as **Development**, **Staging**, or **Production**. They help you manage environment-specific values like base URLs, tokens, or credentials without manually editing each request when switching contexts.
 
 <iframe className="w-full aspect-video rounded-xl" src="https://www.youtube.com/embed/0m00eSkuDcc" />
 

--- a/api-client/environments-and-variables/global-variables.mdx
+++ b/api-client/environments-and-variables/global-variables.mdx
@@ -7,7 +7,7 @@ format: "MDX"
 description: "Learn about global variables in requestly"
 ---
 
-**Global Variables** in Requestly are shared values accessible across all requests, environments, and collections in your workspace. They are ideal for constants or secrets that don’t change frequently—like API keys, common headers, or service base URLs.
+**Global Variables** in Requestly are shared values accessible across all requests, environments, and collections in your workspace. They are ideal for constants or secrets that don’t change frequently, like API keys, common headers, or service base URLs.
 
 Using global variables makes your API collections more reusable, consistent, and easier to update across your workspace.
 

--- a/api-client/environments-and-variables/using-variables-in-api-requests.mdx
+++ b/api-client/environments-and-variables/using-variables-in-api-requests.mdx
@@ -6,7 +6,7 @@ visibility: "PUBLIC"
 format: "MDX"
 ---
 
-Once you've defined variables in Requestly—whether global, environment, collection, or subcollection — you can reference them directly in your API requests. This allows you to dynamically inject values into URLs, headers, request bodies, scripts, and more.
+Once you've defined variables in Requestly, whether global, environment, collection, or subcollection, you can reference them directly in your API requests. This allows you to dynamically inject values into URLs, headers, request bodies, scripts, and more.
 
 ## **Use Variables in API Requests**
 

--- a/api-client/import-export.mdx
+++ b/api-client/import-export.mdx
@@ -30,7 +30,7 @@ This section covers everything you need to know about:
 
 * [Import/Export Environments](/api-client/import-export/import-export-api-environment)
 
-  Bring in or export environment variables like tokens, base URLs, and custom keys — all using simple `.json` files.
+  Bring in or export environment variables like tokens, base URLs, and custom keys, all using simple `.json` files.
 
 * [Import from Postman](/api-client/import-export/import-from-postman)
 

--- a/api-client/import-export/import-openapi-spec.mdx
+++ b/api-client/import-export/import-openapi-spec.mdx
@@ -35,7 +35,7 @@ The importer supports both **YAML** and **JSON** OpenAPI files. When you upload 
     />
   </Step>
   <Step title="Preview Before Import">
-    Requestly will show a preview of what will be imported — including:
+    Requestly will show a preview of what will be imported, including:
 
     - The collections that will be created
     - The environments and variables that will be set up

--- a/api-client/overview.mdx
+++ b/api-client/overview.mdx
@@ -31,14 +31,14 @@ The API Client runs as a **desktop app** on macOS, Windows, and Linux.
 </Tabs>
 
 <Info>
-  **What about the browser extension?** The Requestly browser extension is a separate product — an HTTP interceptor for modifying network traffic. The API Client is a standalone desktop app. You do not need the extension to use the API Client.
+  **What about the browser extension?** The Requestly browser extension is a separate product, an HTTP interceptor for modifying network traffic. The API Client is a standalone desktop app. You do not need the extension to use the API Client.
 </Info>
 
 ***
 
 ## Step 2: Create an Account (Optional)
 
-You can start using the API Client immediately — **no account required**. All requests, collections, and environments are stored locally.
+You can start using the API Client immediately, **no account required**. All requests, collections, and environments are stored locally.
 
 If you want to sync data across devices or collaborate with a team, sign in with your Google or email account from the top-right menu.
 

--- a/api-client/rq-api-reference/rq-collection-variables.mdx
+++ b/api-client/rq-api-reference/rq-collection-variables.mdx
@@ -9,8 +9,6 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
-***
-
 The `rq.collectionVariables` object provides methods to manage collection variables during script execution. Collection variables are scoped to a specific collection and are only accessible within the requests that belong to that collection. Unlike environment variables (scoped to a specific environment), collection variables persist across all environments within the same collection.
 
 ## Methods
@@ -164,5 +162,6 @@ rq.collectionVariables.set("requestSignature", signature);
 - [rq.response Object](/api-client/rq-api-reference/rq-response)
 - [rq.environment Object](/api-client/rq-api-reference/rq-environment)
 - [rq.globals Object](/api-client/rq-api-reference/rq-globals)
+- [rq.vault Object](/api-client/rq-api-reference/rq-vault)
 - [rq.test Object](/api-client/rq-api-reference/rq-test)
 - [rq.expect Object](/api-client/rq-api-reference/rq-expect)

--- a/api-client/rq-api-reference/rq-environment.mdx
+++ b/api-client/rq-api-reference/rq-environment.mdx
@@ -9,8 +9,6 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
-***
-
 The `rq.environment` object provides methods to dynamically manage environment variables during script execution. Environment variables are scoped to a specific environment and can be used across multiple requests within that environment.
 
 ## Methods
@@ -160,5 +158,6 @@ console.log("This request has been made", requestCount + 1, "times");
 - [rq.response Object](/api-client/rq-api-reference/rq-response)
 - [rq.collectionVariables Object](/api-client/rq-api-reference/rq-collection-variables)
 - [rq.globals Object](/api-client/rq-api-reference/rq-globals)
+- [rq.vault Object](/api-client/rq-api-reference/rq-vault)
 - [rq.test Object](/api-client/rq-api-reference/rq-test)
 - [rq.expect Object](/api-client/rq-api-reference/rq-expect)

--- a/api-client/rq-api-reference/rq-expect.mdx
+++ b/api-client/rq-api-reference/rq-expect.mdx
@@ -9,8 +9,6 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
-***
-
 The `rq.expect` object provides assertion methods for writing tests in Requestly. It is built on top of the popular [Chai.js](https://www.chaijs.com/) assertion library, giving you access to powerful and expressive assertions for validating API responses.
 
 <Note>

--- a/api-client/rq-api-reference/rq-globals.mdx
+++ b/api-client/rq-api-reference/rq-globals.mdx
@@ -9,8 +9,6 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
-***
-
 The `rq.globals` object provides methods to manage global variables during script execution. Global variables work similarly to environment variables, but they are available to all collections and requests across all environments. This makes them ideal for storing truly global configuration or state that needs to be shared everywhere.
 
 ## Methods
@@ -193,5 +191,6 @@ Environment Variables > Collection Variables > Global Variables
 - [rq.response Object](/api-client/rq-api-reference/rq-response)
 - [rq.environment Object](/api-client/rq-api-reference/rq-environment)
 - [rq.collectionVariables Object](/api-client/rq-api-reference/rq-collection-variables)
+- [rq.vault Object](/api-client/rq-api-reference/rq-vault)
 - [rq.test Object](/api-client/rq-api-reference/rq-test)
 - [rq.expect Object](/api-client/rq-api-reference/rq-expect)

--- a/api-client/rq-api-reference/rq-request.mdx
+++ b/api-client/rq-api-reference/rq-request.mdx
@@ -7,8 +7,6 @@ seoDescription: "Learn how to use the rq.request object in Requestly to access r
 visibility: "PUBLIC"
 ---
 
----
-
 The `rq.request` object provides access to all details of the API request in your Requestly scripts. You can use these properties and methods in both pre-request and post-response scripts to read  data.
 
 ## Properties and Methods
@@ -98,5 +96,6 @@ rq.request.queryParams.forEach(param => {
 - [rq.environment Object](/api-client/rq-api-reference/rq-environment)
 - [rq.collectionVariables Object](/api-client/rq-api-reference/rq-collection-variables)
 - [rq.globals Object](/api-client/rq-api-reference/rq-globals)
+- [rq.vault Object](/api-client/rq-api-reference/rq-vault)
 - [rq.test Object](/api-client/rq-api-reference/rq-test)
 - [rq.expect Object](/api-client/rq-api-reference/rq-expect)

--- a/api-client/rq-api-reference/rq-response.mdx
+++ b/api-client/rq-api-reference/rq-response.mdx
@@ -9,8 +9,6 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
----
-
 The `rq.response` object provides access to all details of the API response in your Requestly scripts. You can use these properties and methods primarily in post-response scripts to process, validate, and extract data from API responses.
 
 ## Properties and Methods
@@ -163,5 +161,6 @@ if (data.error) {
 - [rq.environment Object](/api-client/rq-api-reference/rq-environment)
 - [rq.collectionVariables Object](/api-client/rq-api-reference/rq-collection-variables)
 - [rq.globals Object](/api-client/rq-api-reference/rq-globals)
+- [rq.vault Object](/api-client/rq-api-reference/rq-vault)
 - [rq.test Object](/api-client/rq-api-reference/rq-test)
 - [rq.expect Object](/api-client/rq-api-reference/rq-expect)

--- a/api-client/rq-api-reference/rq-test.mdx
+++ b/api-client/rq-api-reference/rq-test.mdx
@@ -9,7 +9,6 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
-***
 
 The `rq.test` object allows you to write tests in your post-response scripts to validate API responses and ensure your APIs are working as expected. Tests help you automate quality assurance and catch issues early in development.
 

--- a/api-client/rq-api-reference/rq-vault.mdx
+++ b/api-client/rq-api-reference/rq-vault.mdx
@@ -1,0 +1,161 @@
+---
+title: Vault (rq.vault)
+label: rq.vault
+slug: rq-vault
+description: >-
+  Complete reference for the rq.vault object in Requestly scripts to read and manage encrypted secrets from the local vault and AWS Secrets Manager.
+seoDescription: >-
+  Learn how to use the rq.vault object in Requestly to get, set, unset, and check vault secrets in pre-request and post-response scripts.
+visibility: PUBLIC
+---
+
+The `rq.vault` object provides methods to access encrypted secrets stored in the Requestly [Vault](/api-client/vault) during script execution. Vault secrets are kept out of collections, exports, and cloud sync. Only `{{vault:key}}` references travel with your project, while the resolved values stay on the user's machine.
+
+<Info>
+`rq.vault` is only available in the **Requestly desktop app**. Vault features are disabled in the web-only mode.
+</Info>
+
+## Methods
+
+### `rq.vault.get(key)`
+
+Retrieves the value of a vault secret. Works for both **local** secrets and **AWS Secrets Manager** secrets that have been fetched into the vault.
+
+**Parameters:**
+- `key` (string): The name of the vault secret to retrieve
+
+**Returns:** A `Promise` that resolves to the secret's string value, or `undefined` if the key doesn't exist.
+
+**Example:**
+
+```jsx
+const apiKey = await rq.vault.get("my-api-key");
+console.log("Key loaded:", Boolean(apiKey));
+```
+
+### `rq.vault.set(key, value)`
+
+Creates or updates a **local** vault secret. The value is persisted to encrypted storage via the OS keychain.
+
+**Parameters:**
+- `key` (string): The name of the vault secret to create or update
+- `value` (string): The value to store
+
+**Returns:** A `Promise` that resolves when the secret is persisted.
+
+**Example:**
+
+```jsx
+await rq.vault.set("temp-token", generatedToken);
+```
+
+<Warning>
+`rq.vault.set()` only works on local secrets. Calling it with a key that is already linked to an AWS Secrets Manager entry throws an error. AWS-linked secrets are read-only from scripts.
+</Warning>
+
+### `rq.vault.unset(key)`
+
+Removes a **local** vault secret.
+
+**Parameters:**
+- `key` (string): The name of the vault secret to remove
+
+**Returns:** A `Promise` that resolves when the secret is removed.
+
+**Example:**
+
+```jsx
+await rq.vault.unset("temp-token");
+```
+
+<Warning>
+`rq.vault.unset()` only works on local secrets. It cannot delete AWS-linked secrets. Manage those from the Vault page.
+</Warning>
+
+### `rq.vault.has(key)`
+
+Checks whether a vault secret with the given key exists. Works for both local and AWS secrets.
+
+**Parameters:**
+- `key` (string): The name of the vault secret to check
+
+**Returns:** A `Promise` that resolves to `true` if the secret exists, `false` otherwise.
+
+**Example:**
+
+```jsx
+if (await rq.vault.has("signing-key")) {
+  const key = await rq.vault.get("signing-key");
+  // generate JWT...
+}
+```
+
+## Common Use Cases
+
+### Generate a JWT Without Exposing the Signing Key
+
+Keep the signing key inside the vault and expose only the generated token to the request:
+
+```jsx
+// Pre-request script
+const signingKey = await rq.vault.get("signing-key");
+const jwt = generateJwt(payload, signingKey);
+rq.variables.set("auth-token", jwt);
+```
+
+Then reference `{{auth-token}}` in the Authorization header. The signing key never leaves the vault.
+
+### Cache a Short-Lived Token Locally
+
+Fetch a token once, store it in the vault, and reuse it across subsequent requests until it expires:
+
+```jsx
+let token = await rq.vault.get("session-token");
+
+if (!token) {
+  const res = await fetch("https://auth.example.com/token", { /* ... */ });
+  const body = await res.json();
+  token = body.access_token;
+  await rq.vault.set("session-token", token);
+}
+
+rq.request.headers.add({ key: "Authorization", value: `Bearer ${token}` });
+```
+
+### Guard Optional Secrets
+
+Only apply a signing step when the signing key is configured:
+
+```jsx
+if (await rq.vault.has("hmac-secret")) {
+  const secret = await rq.vault.get("hmac-secret");
+  const signature = signRequest(rq.request.body, secret);
+  rq.request.headers.add({ key: "X-Signature", value: signature });
+}
+```
+
+### Clean Up Temporary Secrets
+
+Remove a short-lived secret once it is no longer needed:
+
+```jsx
+await rq.vault.unset("one-time-code");
+```
+
+## Behavior Notes
+
+- **All methods are asynchronous.** Always `await` them. Synchronous usage will return a `Promise`, not the value.
+- **Values are strings.** Non-string values passed to `set()` should be stringified by the caller (e.g., `JSON.stringify(obj)`).
+- **AWS-linked secrets are read-only.** `set()` and `unset()` only operate on local secrets. Use `get()` / `has()` for AWS secrets.
+- **JSON secrets from AWS auto-expand.** For a secret named `dbCredentials` storing `{ "username": "admin" }`, use `rq.vault.get("dbCredentials.username")` to read the nested value.
+- **Masked in console.** Values returned from `rq.vault.get()` are masked in the Requestly console output. They resolve correctly at request time, but never appear in plaintext in logs.
+- **No cloud sync.** Anything written with `rq.vault.set()` stays on the current machine and is never included in collection exports or workspace sync.
+
+## Related Documentation
+
+- [Vault Overview](/api-client/vault)
+- [Pre-request & Post-response Scripts](/api-client/scripts)
+- [rq.request Object](/api-client/rq-api-reference/rq-request)
+- [rq.response Object](/api-client/rq-api-reference/rq-response)
+- [rq.environment Object](/api-client/rq-api-reference/rq-environment)
+- [rq.globals Object](/api-client/rq-api-reference/rq-globals)

--- a/api-client/vault/aws-secrets-manager.mdx
+++ b/api-client/vault/aws-secrets-manager.mdx
@@ -1,0 +1,181 @@
+---
+title: "AWS Secrets Manager"
+description: "Connect your AWS account to fetch centrally managed secrets into the Requestly vault and reference them in API requests with the {{vault:key}} syntax."
+---
+
+Connect your AWS account to pull centrally managed secrets into the [Vault](/api-client/vault). AWS secrets share the same `{{vault:key}}` namespace as local secrets, so your requests don't need to know where a secret comes from.
+
+<Note>
+AWS Secrets Manager integration requires **Requestly authentication** and an **eligible plan**. Local vault remains fully functional without signing in.
+</Note>
+
+---
+
+## Setting up an AWS provider
+
+<Steps>
+  <Step title="Open the Vault page">
+    Click **Vault** in the app footer.
+  </Step>
+  <Step title="Connect a secret manager">
+    Click **Connect a secret manager** below the Local Secrets section.
+  </Step>
+  <Step title="Enter AWS credentials">
+    Fill in the configuration form:
+
+    | Field | Required | Description |
+    |-------|----------|-------------|
+    | **Display Name** | Yes | A label for this configuration (e.g., "Production", "Staging") |
+    | **Access Key ID** | Yes | Your AWS IAM access key |
+    | **Secret Access Key** | Yes | Your AWS IAM secret key |
+    | **Region** | Yes | AWS region (e.g., `us-east-1`) |
+    | **Session Token** | No | Required only for STS temporary credentials |
+  </Step>
+  <Step title="Test the connection">
+    Click **Test Connection** to validate your credentials against AWS. You can still save even if the test fails and fix credentials later.
+  </Step>
+  <Step title="Save">
+    Click **Save**. The AWS Secrets Manager section appears on the Vault page.
+  </Step>
+</Steps>
+
+---
+
+## Required AWS IAM permissions
+
+Your IAM user or role needs the following permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:*"
+    }
+  ]
+}
+```
+
+<Tip>
+Scope the `Resource` to specific secret ARNs for least-privilege access instead of using `*`.
+</Tip>
+
+---
+
+## Adding and fetching secrets
+
+<Steps>
+  <Step title="Add a secret mapping">
+    In the AWS Secrets Manager section, click **Add Secret**. Enter:
+    - **Alias**: the key you'll use in `{{vault:alias}}`
+    - **Secret Name or ARN**: the AWS secret identifier
+    - **Mode**: `Plaintext` or `JSON`
+  </Step>
+  <Step title="Fetch the secret">
+    Click **Fetch** on the secret row. Requestly calls the AWS `GetSecretValue` API and stores the result encrypted locally.
+  </Step>
+  <Step title="Use it in a request">
+    Reference the secret using `{{vault:alias}}` in any request field. It resolves on send just like a local secret.
+  </Step>
+</Steps>
+
+---
+
+## JSON secrets
+
+When an AWS secret contains a JSON object, Requestly auto-expands it into dot-separated keys:
+
+```
+AWS Secret "dbCredentials":
+{
+  "username": "admin",
+  "password": "s3cret",
+  "host": "db.example.com"
+}
+```
+
+This creates three vault entries:
+- `{{vault:dbCredentials.username}}` resolves to `admin`
+- `{{vault:dbCredentials.password}}` resolves to `s3cret`
+- `{{vault:dbCredentials.host}}` resolves to `db.example.com`
+
+Nested JSON objects expand recursively with dot notation.
+
+---
+
+## Refreshing secrets after rotation
+
+Fetched values are cached locally and persist indefinitely. They survive app restarts and don't auto-expire. When your team rotates a secret in AWS:
+
+1. Open the Vault page
+2. Click **Refresh** on the secret (or **Refresh All** to update all AWS secrets)
+3. The new value replaces the cached one immediately
+
+The **Last Fetched** timestamp on each secret helps you judge staleness.
+
+<Warning>
+There is no automatic refresh. If a secret is rotated in AWS, you must manually refresh to pick up the new value.
+</Warning>
+
+---
+
+## Multiple AWS configurations
+
+You can store multiple AWS configurations (e.g., Production, Staging, EU region) and switch between them:
+
+1. Click the **config selector** in the AWS section header
+2. Select a different configuration. The secrets table swaps to that config's secrets.
+3. `{{vault:key}}` references resolve from the **active** configuration only
+
+Each configuration maintains its own independent set of secrets and cached values. Switching configs preserves all caches, so no re-fetching is needed.
+
+To add a new configuration, select **+ Add new configuration** from the config selector dropdown.
+
+---
+
+## Credential errors
+
+When AWS credentials expire or become invalid:
+
+- The affected secret row shows an error message
+- The provider config section shows an error indicator
+- Previously cached values **remain available**. Requests continue working with the last fetched value.
+
+To fix: edit your credentials in the same provider config form (no separate reauthentication flow), save, and retry the fetch.
+
+---
+
+## Move to Local
+
+You can convert any AWS secret to a local vault secret:
+
+1. Select **Move to Local** on an AWS secret
+2. The secret moves to the Local Secrets section with the last fetched value preserved
+3. It becomes fully editable and is no longer linked to AWS
+
+---
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Can I use multiple AWS accounts at the same time?">
+    You can store multiple AWS configurations, but only one is active at a time. The active config's secrets are the ones that resolve via `{{vault:key}}`. Switch between configs using the config selector in the AWS section header.
+  </Accordion>
+  <Accordion title="Do vault secrets auto-refresh when rotated in AWS?">
+    No. Fetched values are cached locally and persist until you manually refresh. Click **Refresh** on a secret (or **Refresh All**) to pull the latest value from AWS.
+  </Accordion>
+  <Accordion title="Can scripts modify AWS secrets?">
+    No. `rq.vault.set()` and `rq.vault.unset()` only work on local secrets. AWS secrets are read-only from scripts. Use `rq.vault.get()` to read them.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related Documentation
+
+- [Vault Overview](/api-client/vault)
+- [`rq.vault` Scripting API](/api-client/rq-api-reference/rq-vault)

--- a/api-client/vault/vault.mdx
+++ b/api-client/vault/vault.mdx
@@ -1,0 +1,166 @@
+---
+title: "Overview"
+description: "Store sensitive values locally, pull secrets from external providers like AWS Secrets Manager, and reference them in your API requests without ever exposing credentials in collections, exports, or cloud sync."
+---
+
+## What is Vault ?
+
+Vault is a local-first encrypted secrets store built into the Requestly desktop app. It lets you:
+
+- **Store secrets locally**: API keys, tokens, and passwords encrypted on your machine via OS keychain.
+- **Pull secrets from external providers**: connect services like [AWS Secrets Manager](/api-client/vault/aws-secrets-manager) to fetch centrally managed credentials.
+- **Reference secrets in requests**: use `{{vault:key}}` syntax in URLs, headers, auth fields, and body.
+- **Share collections safely**: secret references travel with collections, but values stay on each user's machine.
+
+<Info>
+Vault requires the **Requestly desktop app** (Electron) for OS-level encryption via `safeStorage`. Vault features are not available in the web-only mode.
+</Info>
+
+---
+
+## Local Vault
+
+The local vault is available to **all users**. No sign-in or paid plan is required. Secrets are encrypted at rest using your operating system's keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service).
+
+### Creating a local secret
+
+<Steps>
+  <Step title="Open the Vault">
+    Click the **Vault** button in the app footer to open the Vault page.
+  </Step>
+  <Step title="Add a secret">
+    Click **Add Secret** at the bottom of the Local Secrets table. A new row appears with editable Key and Value cells.
+  </Step>
+  <Step title="Enter key and value">
+    Type a key name (e.g., `my-api-key`) and a value (e.g., `sk-abc123`). Press **Enter** to save. The value masks immediately.
+  </Step>
+</Steps>
+
+### Using a vault secret in a request
+
+Reference any vault secret using the `{{vault:key}}` syntax in any request field:
+
+```
+Authorization: Bearer {{vault:my-api-key}}
+```
+
+When you send the request, `{{vault:my-api-key}}` resolves to the actual value. The resolved value **never** appears in the editor, console output, collection exports, or cloud sync. Only the `{{vault:key}}` reference is visible.
+
+<Tip>
+Vault secrets appear in the standard `{{` autocomplete dropdown alongside environment and collection variables, labeled with a **Vault** scope badge.
+</Tip>
+
+### Inline editing
+
+Click any key or value cell in the vault table to edit it in place. No modals or separate forms are needed. Changes save automatically on blur or Enter.
+
+### Deleting a secret
+
+Delete a vault secret from the table. Any `{{vault:key}}` references to the deleted secret become unresolved immediately.
+
+---
+
+## External secret providers
+
+Connect centrally managed secret managers to pull secrets into the vault. External provider secrets share the same `{{vault:key}}` namespace as local secrets, so your requests don't need to know where a secret comes from.
+
+- [**AWS Secrets Manager**](/api-client/vault/aws-secrets-manager): connect an AWS account to fetch and cache secrets, with support for JSON expansion, multiple configurations, and rotation refresh.
+
+<Note>
+External provider integrations require **Requestly authentication** and an **eligible plan**. Local vault remains fully functional without signing in.
+</Note>
+
+---
+
+## Scripting API
+
+Access vault secrets programmatically in pre-request and post-response scripts using the `rq.vault` API:
+
+```javascript
+// Pre-request script
+const signingKey = await rq.vault.get('signing-key');
+const jwt = generateJwt(payload, signingKey);
+rq.variables.set('auth-token', jwt);
+```
+
+Then use `{{auth-token}}` in the Authorization header. The signing key never leaves the vault.
+
+See the full [`rq.vault` reference](/api-client/rq-api-reference/rq-vault) for `get`, `set`, `unset`, and `has` methods.
+
+---
+
+## Importing from Postman
+
+Requestly preserves `{{vault:key}}` references when importing Postman collections. No syntax translation is needed.
+
+### What happens on import
+
+1. `{{vault:key}}` references in URLs, headers, auth fields, and body are **preserved as-is**.
+2. `pm.vault.get/set/unset/has` calls in scripts are **automatically translated** to `rq.vault.get/set/unset/has`.
+3. For each detected `{{vault:key}}` reference, a **local secret is pre-created** with an empty value.
+4. A post-import summary lists the pre-created secrets.
+
+### After import
+
+Open the Vault page. You'll see the pre-created secret keys with empty values. Fill in the values, and your imported requests will resolve immediately.
+
+<Info>
+Postman collection exports never include vault secret values, only the `{{vault:key}}` references. You'll need to re-enter the actual values in your Requestly vault.
+</Info>
+
+---
+
+## Namespace and resolution
+
+### Resolution priority
+
+If the same key exists in both Local Secrets and an external provider (e.g., AWS), the **external secret wins**. The local secret shows an amber "overridden by duplicate key" warning.
+
+### Variable hover
+
+Hovering over a `{{vault:key}}` reference in any editor field shows:
+- The masked value (`••••••••`)
+- The scope: **Vault**
+- The source: **Local** or the external provider name
+
+Unresolved references show an "Unresolved" diagnostic with guidance.
+
+### Console masking
+
+Vault secret values are **always masked** in the console and response viewer. You'll see the `{{vault:key}}` reference or `••••••••`, never the plaintext value.
+
+---
+
+## Security model
+
+| Property | Behavior |
+|----------|----------|
+| **Encryption at rest** | All vault data encrypted via Electron `safeStorage` (OS keychain). Files on disk are not human-readable. |
+| **Device isolation** | Each OS user account has a separate vault. A different OS user on the same machine cannot access your secrets. |
+| **No cloud sync** | Vault values are never sent to Requestly servers, never included in cloud workspace sync. |
+| **No export inclusion** | Collection exports contain `{{vault:key}}` references, never resolved values. |
+| **Provider credentials** | Stored encrypted alongside vault secrets. Never appear in logs or plaintext files. |
+| **Session independence** | Local vault works regardless of sign-in state. External provider features require authentication. |
+
+<Warning>
+**Linux users:** Vault requires a D-Bus Secret Service implementation (GNOME Keyring, KWallet, or equivalent). If no keyring is configured, vault features are disabled but the rest of the app works normally.
+</Warning>
+
+---
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Does vault work in the web app?">
+    No. Vault requires the desktop app (Electron) for OS-level encryption. This matches how Postman's vault requires the Desktop Agent.
+  </Accordion>
+  <Accordion title="What happens if I sign out?">
+    Local vault secrets persist and continue resolving. They're tied to your OS user session, not your Requestly account. Previously fetched external provider secrets also remain cached and resolvable. However, you cannot configure new providers or fetch new secrets until you sign back in.
+  </Accordion>
+  <Accordion title="What happens to vault references in CI/CD?">
+    Vault is desktop-only and does not work in CI/CD pipelines. For automated runs, use environment variables or your CI platform's native secret injection.
+  </Accordion>
+  <Accordion title="Can scripts modify secrets from external providers?">
+    No. `rq.vault.set()` and `rq.vault.unset()` only work on local secrets. External provider secrets are read-only from scripts. Use `rq.vault.get()` to read them.
+  </Accordion>
+</AccordionGroup>

--- a/changelogs/jun-2-2025.mdx
+++ b/changelogs/jun-2-2025.mdx
@@ -13,7 +13,7 @@ visibility: PUBLIC
 
 * API Client no longer crashes when viewed in a logged-out state.
 
-* Fixed issues where request body positioning caused confusion — now properly moved to the bottom.
+* Fixed issues where request body positioning caused confusion, now properly moved to the bottom.
 
 * Fixed unexpected error when a user aborts execution in the API Client.
 

--- a/changelogs/june-30-2025.mdx
+++ b/changelogs/june-30-2025.mdx
@@ -19,4 +19,4 @@ visibility: PUBLIC
 
 * Fixed an issue where the Network Details panel would disappear from the recorded session on hover.
 
-* Collections are now imported with the correct hierarchy and order — previously, they appeared as a flat list.
+* Collections are now imported with the correct hierarchy and order, previously, they appeared as a flat list.

--- a/collaboration/how-to-get-started-with-shared-workspace/user-roles.mdx
+++ b/collaboration/how-to-get-started-with-shared-workspace/user-roles.mdx
@@ -15,7 +15,7 @@ In this doc, you'll learn how Requestly's RBAC works, the specific roles availab
 
 ## How RBAC Works in Requestly
 
-Requestly uses role-based access control (RBAC) to ensure that every team member only gets access to what they need. It has three roles — **Admin**, **Editor**, and **Viewer**, each with permissions to protect sensitive data like API keys and tokens and reduce mistakes or unauthorised changes, making teamwork smoother and more efficient.
+Requestly uses role-based access control (RBAC) to ensure that every team member only gets access to what they need. It has three roles, **Admin**, **Editor**, and **Viewer**, each with permissions to protect sensitive data like API keys and tokens and reduce mistakes or unauthorised changes, making teamwork smoother and more efficient.
 
 ## User Roles and Their Permissions
 

--- a/collaboration/workspaces.mdx
+++ b/collaboration/workspaces.mdx
@@ -2,7 +2,7 @@
 title: Introduction
 label: Overview
 slug: workspaces
-description: Learn about projects and workspaces in Requestly — how to organize your rules, mocks, and API requests and collaborate with your team.
+description: Learn about projects and workspaces in Requestly, how to organize your rules, mocks, and API requests and collaborate with your team.
 visibility: PUBLIC
 ---
 
@@ -22,9 +22,9 @@ This setup is ideal for personal work or testing. However, you can create additi
 
 Requestly offers two main types of projects:
 
-**Team project** — A team project is cloud-based: all your data is securely stored and synced across teams and devices. This is ideal when you work with a team and need everyone to stay in sync.
+**Team project**, A team project is cloud-based: all your data is securely stored and synced across teams and devices. This is ideal when you work with a team and need everyone to stay in sync.
 
-**Local project (beta)** — A local project stores all your data on your computer, giving you complete control and privacy. It is designed for individual use rather than team collaboration. Choose this option if you prefer local storage over the cloud.
+**Local project (beta)**, A local project stores all your data on your computer, giving you complete control and privacy. It is designed for individual use rather than team collaboration. Choose this option if you prefer local storage over the cloud.
 
 ## Explore
 

--- a/docs.json
+++ b/docs.json
@@ -78,7 +78,14 @@
                   "api-client/environments-and-variables/runtime-variables",
                   "api-client/environments-and-variables/dynamic-variables",
                   "api-client/environments-and-variables/variable-precedence",
-                  "api-client/environments-and-variables/using-variables-in-api-requests"
+                  "api-client/environments-and-variables/using-variables-in-api-requests",
+                  {
+                    "group": "Vault",
+                    "pages": [
+                      "api-client/vault/vault",
+                      "api-client/vault/aws-secrets-manager"
+                    ]
+                  }
                 ]
               },
               {
@@ -105,6 +112,7 @@
                   "api-client/rq-api-reference/rq-environment",
                   "api-client/rq-api-reference/rq-collection-variables",
                   "api-client/rq-api-reference/rq-globals",
+                  "api-client/rq-api-reference/rq-vault",
                   "api-client/rq-api-reference/rq-test",
                   "api-client/rq-api-reference/rq-expect",
                   "api-client/rq-api-reference/rq-iteration-data",

--- a/http-interception/getting-started/difference-between-desktop-app-and-browser-extension.mdx
+++ b/http-interception/getting-started/difference-between-desktop-app-and-browser-extension.mdx
@@ -10,15 +10,15 @@ seoDescription: >-
 visibility: PUBLIC
 ---
 
-Requestly offers two ways to intercept and modify HTTP traffic. Use the right one for your workflow — or use both in combination.
+Requestly offers two ways to intercept and modify HTTP traffic. Use the right one for your workflow, or use both in combination.
 
 <CardGroup cols={2}>
   <Card title="Browser Extension" icon="browser" href="/http-interception/getting-started/quick-start-guide/browser-extension-setup">
-    **Best for:** Intercepting and modifying traffic from inside the browser — fast setup, no configuration.
+    **Best for:** Intercepting and modifying traffic from inside the browser, fast setup, no configuration.
   </Card>
 
   <Card title="Desktop App" icon="desktop" href="/http-interception/getting-started/quick-start-guide/desktop-app-setup">
-    **Best for:** System-wide traffic interception — desktop apps, mobile devices, simulators, terminal, Node.js.
+    **Best for:** System-wide traffic interception, desktop apps, mobile devices, simulators, terminal, Node.js.
   </Card>
 </CardGroup>
 

--- a/http-interception/getting-started/quick-start-guide/browser-extension-setup.mdx
+++ b/http-interception/getting-started/quick-start-guide/browser-extension-setup.mdx
@@ -25,7 +25,7 @@ With the Browser Extension, you can:
    the Requestly Interceptor extension for your favorite browser.
 </Info>
 
-The extension uses your browser’s native network APIs, which means **no conflicts with VPNs or proxies** — and it runs seamlessly without installing any system-level tools.
+The extension uses your browser’s native network APIs, which means **no conflicts with VPNs or proxies**, and it runs seamlessly without installing any system-level tools.
 
 ### **Extension Popup**
 
@@ -52,11 +52,11 @@ The Web App can be accessed using the `Open App` button in the Extension Popup
 
 1. **Home**: The homepage provides an overview of your resources and quick access to key actions.
 2. **Network Inspector**: Similar to the browser’s dev tools, but with additional features.
-3. **HTTP Rules**: Allows you to override network requests by modifying parts of the request or redirecting them—our most popular feature.
+3. **HTTP Rules**: Allows you to override network requests by modifying parts of the request or redirecting them, our most popular feature.
 4. **Sessions**: Contains saved sessions from the Extension Popup discussed earlier.
 5. **File Server**: Allows you to host custom files and mock endpoints in the cloud so you can test APIs and resource overrides with shareable URLs.
 
-Each area has its own documentation—use the sidebar to explore Network Inspector, HTTP Rules, Sessions, and File Server.
+Each area has its own documentation, use the sidebar to explore Network Inspector, HTTP Rules, Sessions, and File Server.
 
 <img
   src="/images/browser-extention-setup/2133a708-b409-4802-b4bb-ae45f034747c.png"
@@ -66,21 +66,21 @@ Each area has its own documentation—use the sidebar to explore Network Inspect
 
 **On Top (from left to right)**
 
-1. **Workspace Selector** — Allows you to create a new workspace or switch between existing ones. Workspaces are where you group your work for specific teams or projects.
-2. **Star** — A GitHub widget to star our repository and track Requestly Interceptor’s development.
-3. **Search** — Helps you quickly navigate the app; search for an action like “Create New Workspace” and hit enter to quickly create new workspace.
-4. **Ask AI** — An AI bot that can instantly assist with most queries. While our support team is prompt, AI provides even faster responses.
-5. **Settings (Cog Icon)** — Opens the settings page, where you can configure Requestly Interceptor to suit your needs.
-6. **Profile Picture Dropdown** — Displays your logged-in profile information and includes links to billing and logout.
+1. **Workspace Selector** , Allows you to create a new workspace or switch between existing ones. Workspaces are where you group your work for specific teams or projects.
+2. **Star** , A GitHub widget to star our repository and track Requestly Interceptor’s development.
+3. **Search** , Helps you quickly navigate the app; search for an action like “Create New Workspace” and hit enter to quickly create new workspace.
+4. **Ask AI** , An AI bot that can instantly assist with most queries. While our support team is prompt, AI provides even faster responses.
+5. **Settings (Cog Icon)** , Opens the settings page, where you can configure Requestly Interceptor to suit your needs.
+6. **Profile Picture Dropdown** , Displays your logged-in profile information and includes links to billing and logout.
 
 **On the Bottom Left**
 
-1. **Invite Button** — This lets you invite teammates to collaborate on Requestly Interceptor.
-2. **Version Information** — Displays the current version of Requestly Interceptor, which can be helpful when communicating with our support team.
+1. **Invite Button** , This lets you invite teammates to collaborate on Requestly Interceptor.
+2. **Version Information** , Displays the current version of Requestly Interceptor, which can be helpful when communicating with our support team.
 
 **On the Bottom Right**
 
-1. **Chat Support Icon** — Located slightly above the API Documentation link, this connects you to our dedicated customer support team.
+1. **Chat Support Icon** , Located slightly above the API Documentation link, this connects you to our dedicated customer support team.
 
 ## When To Use The Browser Extension
 

--- a/http-interception/getting-started/quick-start-guide/desktop-app-setup.mdx
+++ b/http-interception/getting-started/quick-start-guide/desktop-app-setup.mdx
@@ -32,11 +32,11 @@ The Desktop application offers additional features compared to the Browser Exten
 
 The Desktop App interface closely mirrors the Web App interface, maintaining a consistent experience across platforms. However, there are some key differences from the Browser Extension:
 
-1. **Network Traffic Tab** — Located on the left sidebar, this is the main feature of the Desktop App. It enables you to intercept traffic from desktop apps, Android simulators, iOS simulators, and even proxy traffic from mobile apps for detailed analysis.
+1. **Network Traffic Tab** , Located on the left sidebar, this is the main feature of the Desktop App. It enables you to intercept traffic from desktop apps, Android simulators, iOS simulators, and even proxy traffic from mobile apps for detailed analysis.
 
-2. **Proxy Server Indicator** — The `Proxy Server is listening` bar indicates that the proxy server is running on the Desktop App. It is used to intercept traffic from the various places mentioned above and display it in the Network Traffic table. Clicking the `Connect apps` button provides options to connect to browsers, desktop apps, mobile simulators, mobile apps, and more.
+2. **Proxy Server Indicator** , The `Proxy Server is listening` bar indicates that the proxy server is running on the Desktop App. It is used to intercept traffic from the various places mentioned above and display it in the Network Traffic table. Clicking the `Connect apps` button provides options to connect to browsers, desktop apps, mobile simulators, mobile apps, and more.
 
-3. **Sessions** — Sessions in the Desktop App are recorded from the Network Traffic table, making them slightly different from the Web App. These sessions can be used for reference or to create bulk mocks.
+3. **Sessions** , Sessions in the Desktop App are recorded from the Network Traffic table, making them slightly different from the Web App. These sessions can be used for reference or to create bulk mocks.
 
 4. Apart from these differences, the rest of the interface remains the same as the Web App.
 

--- a/http-interception/guides/community-content/README.md
+++ b/http-interception/guides/community-content/README.md
@@ -10,10 +10,10 @@ Community Content includes user-contributed documentation, tutorials, guides, an
 
 We welcome various types of content, including:
 
-- **Tutorials & Guides** — Step-by-step use cases, integrations, and best practices  
-- **Use Cases & Examples** — Real-world debugging, API testing, automation workflows  
-- **Code Snippets** — Scripts, regex patterns, and JS snippets  
-- **Videos** — Tutorials, screencasts, and workshop recordings  
+- **Tutorials & Guides**, Step-by-step use cases, integrations, and best practices  
+- **Use Cases & Examples**, Real-world debugging, API testing, automation workflows  
+- **Code Snippets**, Scripts, regex patterns, and JS snippets  
+- **Videos**, Tutorials, screencasts, and workshop recordings  
 
 ## How to Contribute
 

--- a/http-interception/guides/community-content/using-collection-runner-in-requestly.mdx
+++ b/http-interception/guides/community-content/using-collection-runner-in-requestly.mdx
@@ -10,7 +10,7 @@ difficulty: beginner
 
 ## Introduction
 
-"What if I could test all my APIs at once — like a chain reaction — without switching tabs or hitting Send repeatedly?"
+"What if I could test all my APIs at once, like a chain reaction, without switching tabs or hitting Send repeatedly?"
 
 If you've ever tested APIs manually, you know the pain:
 
@@ -19,9 +19,9 @@ If you've ever tested APIs manually, you know the pain:
 3. Paste it into the next request
 4. Then test one endpoint after another
 
-It's repetitive and time-consuming — especially when you're testing a whole workflow like **Login → Create User → Fetch User → Delete User**.
+It's repetitive and time-consuming, especially when you're testing a whole workflow like **Login → Create User → Fetch User → Delete User**.
 
-That's where Requestly Interceptor's Collection Runner shines. In this guide, I'll walk you through how I explored the Collection Runner feature, how it simplifies API automation, and how you can start using it right away — even if you're completely new to automated API testing.
+That's where Requestly Interceptor's Collection Runner shines. In this guide, I'll walk you through how I explored the Collection Runner feature, how it simplifies API automation, and how you can start using it right away, even if you're completely new to automated API testing.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ The Collection Runner in Requestly Interceptor lets you execute multiple saved A
 
 Imagine chaining requests together: **Login → Create User → Fetch User → Delete User**
 
-You can run them one after another, apply test scripts, reuse variables, and even debug results visually — all without writing a single line of backend automation code.
+You can run them one after another, apply test scripts, reuse variables, and even debug results visually, all without writing a single line of backend automation code.
 
 ## Step-by-Step Guide
 
@@ -50,10 +50,10 @@ I named mine **User Management APIs**, because I wanted to simulate a typical CR
 
 Inside my collection, I added the following 4 requests:
 
-1. `GET /users` — Fetch all users
-2. `GET /users/1` — Get a specific user
-3. `POST /users` — Create a new user
-4. `DELETE /users/1` — Delete a user (mock)
+1. `GET /users`, Fetch all users
+2. `GET /users/1`, Get a specific user
+3. `POST /users`, Create a new user
+4. `DELETE /users/1`, Delete a user (mock)
 
 ![Setting Up](/images/using-collection-runner-in-requestly/setting-up.png)
 
@@ -98,7 +98,7 @@ rq.test("Response body is JSON object", () => {
 
 ![Scripts](/images/using-collection-runner-in-requestly/add-scripts.png)
 
-These tests automatically validate the response when your collection runs. So now, after every run, I could instantly see if a request passed or failed — without manually checking the response body.
+These tests automatically validate the response when your collection runs. So now, after every run, I could instantly see if a request passed or failed, without manually checking the response body.
 
 ### Step 3: Running All Your Requests at Once
 
@@ -110,23 +110,23 @@ This opened the Collection Runner, where I could configure:
 
 - **Iterations**: How many times to repeat the run
 - **Delay**: How long to wait between requests (useful if your server needs a breather)
-- **Select data file**: Optional — useful if you want to pass different input sets for multiple runs
+- **Select data file**: Optional, useful if you want to pass different input sets for multiple runs
 
 ### Step 4: Reordering or Skipping Requests
 
-Here's something I really liked — before running, I could reorder the requests or uncheck the ones I didn't want to include.
+Here's something I really liked, before running, I could reorder the requests or uncheck the ones I didn't want to include.
 
 I dragged my "Delete User" request to the end (because, obviously, who deletes before testing?). That small UX detail made the workflow feel super flexible.
 
 ![Reordering](/images/using-collection-runner-in-requestly/reordering.png)
 
-After setting everything up, I hit **Run Collection** — and boom! Requestly Interceptor started running all my requests in order, one after another, while I just watched it go.
+After setting everything up, I hit **Run Collection**, and boom! Requestly Interceptor started running all my requests in order, one after another, while I just watched it go.
 
 ![Collection-Running](/images/using-collection-runner-in-requestly/collection-successful-running.png)
 
 ### Step 5: Making It Dynamic with Variables & Environments
 
-Hardcoding URLs and values works for one-time tests — but it quickly becomes a hassle when switching between environments like dev, staging, or prod.
+Hardcoding URLs and values works for one-time tests, but it quickly becomes a hassle when switching between environments like dev, staging, or prod.
 
 That's where variables come in. Instead of writing full URLs, you can use placeholders like:
 
@@ -144,7 +144,7 @@ This way, you can easily switch between different environments without modifying
 
 After running my JSONPlaceholder collection, Requestly Interceptor displayed a **Run Summary** that instantly made everything click.
 
-It didn't just show "pass" or "fail" — it broke everything down clearly:
+It didn't just show "pass" or "fail", it broke everything down clearly:
 
 - ✅ Number of passed tests
 - ❌ Number of failed tests
@@ -166,7 +166,7 @@ Another really neat feature is the **History** tab in the top right corner. It a
 - Compare results between test iterations
 - Track when something started failing
 
-That means you can build up a timeline of test runs — perfect for debugging or regression tracking later on.
+That means you can build up a timeline of test runs, perfect for debugging or regression tracking later on.
 
 ## What's Actually Happening Behind the Scenes
 
@@ -178,7 +178,7 @@ Here's a simple breakdown of what goes on under the hood when you click **Run**:
 4. Post-response tests run automatically
 5. Everything is logged in the Test results for you to analyze
 
-It's basically like having a mini continuous testing pipeline, right inside Requestly Interceptor — but without the complexity of CI/CD setup.
+It's basically like having a mini continuous testing pipeline, right inside Requestly Interceptor, but without the complexity of CI/CD setup.
 
 ## Examples
 
@@ -206,11 +206,11 @@ The Collection Runner in Requestly Interceptor turns API testing from a manual c
 - The results dashboard provides instant visibility into test outcomes
 - History tracking helps with debugging and regression analysis
 
-It's like giving your APIs an autopilot mode. Try it once — and you'll never want to test manually again.
+It's like giving your APIs an autopilot mode. Try it once, and you'll never want to test manually again.
 
 ## Additional Resources
 
-- [Requestly Interceptor Documentation — Collection Runner](https://docs.requestly.com)
+- [Requestly Interceptor Documentation, Collection Runner](https://docs.requestly.com)
 - [Try Requestly Interceptor App](https://app.requestly.io)
 - [GitHub Docs Repo](https://github.com/requestly/requestly-docs)
 - [JSONPlaceholder Fake REST API](https://jsonplaceholder.typicode.com)

--- a/http-interception/guides/community-content/using-git-with-local-workspace-in-requestly.mdx
+++ b/http-interception/guides/community-content/using-git-with-local-workspace-in-requestly.mdx
@@ -10,7 +10,7 @@ difficulty: beginner
 
 ## Introduction
 
-Imagine treating your API collections with the same care you give your codebase—tracking every change, collaborating effortlessly with your team, and having the confidence to experiment knowing you can always roll back. That's exactly what happens when you connect Requestly's Local Workspace with Git.
+Imagine treating your API collections with the same care you give your codebase, tracking every change, collaborating effortlessly with your team, and having the confidence to experiment knowing you can always roll back. That's exactly what happens when you connect Requestly's Local Workspace with Git.
 
 Your API work becomes versioned, shareable, and reviewable. Team members can contribute to the same collections, changes are tracked automatically, and everyone stays in sync. Whether you're building a new API ecosystem or maintaining existing ones, Git transforms your workspace into a collaborative hub that evolves with your team.
 
@@ -22,11 +22,11 @@ Let's explore how to set this up and unlock a more professional workflow for you
 
 Before diving in, make sure you have:
 
-- **[Requestly Desktop App](https://requestly.com/downloads)** — For creating and managing Local Workspaces
-- **[Git](https://git-scm.com/downloads)** — Installed and configured on your machine
-- **[GitHub Account](https://github.com)** — To host your repository and enable team collaboration
+- **[Requestly Desktop App](https://requestly.com/downloads)**, For creating and managing Local Workspaces
+- **[Git](https://git-scm.com/downloads)**, Installed and configured on your machine
+- **[GitHub Account](https://github.com)**, To host your repository and enable team collaboration
 
-If you're already using Git for your code, you're all set—this will feel familiar.
+If you're already using Git for your code, you're all set, this will feel familiar.
 
 ---
 
@@ -34,7 +34,7 @@ If you're already using Git for your code, you're all set—this will feel famil
 
 ### 1. Create Your Local Workspace
 
-Open the Requestly Desktop App and create a new Local Workspace. You'll be asked to choose a folder on your system—pick somewhere dedicated to your API work. This folder will hold all your collections, requests, and configurations as actual files on your machine.
+Open the Requestly Desktop App and create a new Local Workspace. You'll be asked to choose a folder on your system, pick somewhere dedicated to your API work. This folder will hold all your collections, requests, and configurations as actual files on your machine.
 
 ![Create Workspace](/images/how-to-use-git-with-local-workspace/creating-workspace.gif)
 
@@ -46,7 +46,7 @@ Once created, start building your API collections just as you normally would. Th
 
 ### 2. Connect to Git and Share with Your Team
 
-Now comes the powerful part—turning your local workspace into a version-controlled, shareable project. Here's how:
+Now comes the powerful part, turning your local workspace into a version-controlled, shareable project. Here's how:
 
 1. **Create a GitHub repository**
 
@@ -158,9 +158,9 @@ This bidirectional workflow means everyone can contribute, review changes, and s
 
 You've just elevated your API workflow to match the professionalism of your code development. Here's what you've unlocked:
 
-- **Version control** — Complete history of every change made
-- **Team collaboration** — Work together without conflicts
-- **Flexibility** — Branch, experiment, and roll back with confidence
+- **Version control**, Complete history of every change made
+- **Team collaboration**, Work together without conflicts
+- **Flexibility**, Branch, experiment, and roll back with confidence
 
 All the Git patterns you know and trust now apply to your API work. If something breaks, roll back. If someone makes an interesting change, review it. If you want to experiment, create a branch.
 

--- a/http-interception/guides/community-content/using-graphql-in-requestly.mdx
+++ b/http-interception/guides/community-content/using-graphql-in-requestly.mdx
@@ -26,10 +26,10 @@ GraphQL is a powerful query language that gives you precise control over your AP
 
 **Why developers love it:**
 
-- **No over-fetching** — Get only the fields you need, not the entire object
-- **No under-fetching** — Fetch related data in one go instead of making multiple calls
-- **Strongly typed** — Know exactly what data is available through the schema
-- **Single endpoint** — One URL for all your operations
+- **No over-fetching**, Get only the fields you need, not the entire object
+- **No under-fetching**, Fetch related data in one go instead of making multiple calls
+- **Strongly typed**, Know exactly what data is available through the schema
+- **Single endpoint**, One URL for all your operations
 
 Instead of juggling multiple endpoints like `/users/1`, `/users/1/posts`, and `/users/1/comments`, you make one GraphQL request that gets everything you need.
 
@@ -69,7 +69,7 @@ That's the foundation. Now let's see how Requestly makes working with these oper
 
 We'll use a free GraphQL API to explore how Requestly simplifies everything: `https://graphqlzero.almansi.me/api`
 
-This API provides a complete playground with users, posts, and comments—perfect for learning.
+This API provides a complete playground with users, posts, and comments, perfect for learning.
 
 ---
 
@@ -90,7 +90,7 @@ The schema explorer shows you every query, mutation, and type definition availab
 
 ### 2. Writing Queries
 
-Requestly gives you flexibility—write queries manually with intelligent autocomplete, or use the visual interface for a code-free experience.
+Requestly gives you flexibility, write queries manually with intelligent autocomplete, or use the visual interface for a code-free experience.
 
 **Manual Approach:** Type your query directly in the editor. As you type, Requestly suggests available fields and validates your query structure in real-time.
 
@@ -172,7 +172,7 @@ query GetUser($userId: ID!) {
 }
 ```
 
-Need a different user? Just change `"2"` to `"5"` in the variables—no need to touch your query.
+Need a different user? Just change `"2"` to `"5"` in the variables, no need to touch your query.
 
 ![Query with Variables in GraphQL](/images/using-graphql/query-with-variables.gif)
 
@@ -254,11 +254,11 @@ This is incredibly useful when testing multiple operations without switching bet
 
 You've just learned how to work efficiently with GraphQL in Requestly. Here's what you can now do:
 
-- **Auto-fetch schemas** — No more hunting for documentation
-- **Write queries two ways** — Code or visual interface, your choice
-- **Use variables** — Make dynamic, reusable queries
-- **Execute mutations** — Create, update, and delete data with confidence
-- **Manage multiple operations** — Keep related queries and mutations together, switch between them instantly
+- **Auto-fetch schemas**, No more hunting for documentation
+- **Write queries two ways**, Code or visual interface, your choice
+- **Use variables**, Make dynamic, reusable queries
+- **Execute mutations**, Create, update, and delete data with confidence
+- **Manage multiple operations**, Keep related queries and mutations together, switch between them instantly
 
 Requestly transforms GraphQL from complex to accessible. Whether you're a developer who loves writing queries or a team member who prefers clicking buttons, you have the tools you need.
 

--- a/http-interception/guides/community-content/using-local-workspace-in-requestly.mdx
+++ b/http-interception/guides/community-content/using-local-workspace-in-requestly.mdx
@@ -1,22 +1,22 @@
 ---
-title: Getting Started with Requestly’s Local Workspace — My Hands-On Experience
+title: "Getting Started with Requestly’s Local Workspace: My Hands-On Experience"
 author: Bhogeshwarj
 authorUrl: https://github.com/bhogeshwarj
 date: 2025-12-06
-description: A beginner-friendly hands-on guide to exploring Requestly’s Local Workspace — creating workspaces, collections, requests, and deleting workspaces safely.
+description: A beginner-friendly hands-on guide to exploring Requestly’s Local Workspace, creating workspaces, collections, requests, and deleting workspaces safely.
 tags: [requestly, api-testing, local-workspace, beginners-guide, productivity]
 difficulty: beginner
 ---
 
 ## Introduction
 
-As developers, we love tools that save time, reduce friction, and give us control. Requestly has always been one of those tools — especially for testing APIs, debugging network calls, managing headers, redirects, and more.
+As developers, we love tools that save time, reduce friction, and give us control. Requestly has always been one of those tools, especially for testing APIs, debugging network calls, managing headers, redirects, and more.
 
-While exploring Requestly, I stumbled upon something new that immediately grabbed my attention — Local Workspace.
+While exploring Requestly, I stumbled upon something new that immediately grabbed my attention, Local Workspace.
 
 At first, I assumed it was just another workspace option. But once I actually used it, I realized:
 
-> This is a totally different way to organize and test APIs — privately, offline, and with full control.
+> This is a totally different way to organize and test APIs, privately, offline, and with full control.
 
 If you’ve ever wished:
 
@@ -26,13 +26,13 @@ If you’ve ever wished:
 
 … then Local Workspace might be exactly what you need.
 
-So here’s my experience using it for the first time — step-by-step, what worked, what surprised me, and how you can try it too.
+So here’s my experience using it for the first time, step-by-step, what worked, what surprised me, and how you can try it too.
 
 ---
 
 ## 🧠 What is Local Workspace (in the simplest words)?
 
-Local Workspace lets you create a Requestly workspace whose data is stored only on your computer — not online, not synced, not shared.
+Local Workspace lets you create a Requestly workspace whose data is stored only on your computer, not online, not synced, not shared.
 
 Everything stays in a folder you choose:
 
@@ -46,21 +46,21 @@ It’s like having Postman collections + VSCode folder + Git version control all
 > No team, no cloud, no login required.  
 > Just you and your local machine.
 
-This was a big win for me because I often test APIs that are still internal or experimental — now I don’t have to worry about where the data goes.
+This was a big win for me because I often test APIs that are still internal or experimental, now I don’t have to worry about where the data goes.
 
 ---
 
 ## 🚀 Setting up a Local Workspace
 
-### Step 1 — Open Requestly
+### Step 1: Open Requestly
 
-### Step 2 — Click on Workspaces
+### Step 2: Click on Workspaces
 
-### Step 3 — Choose “New local workspace”
+### Step 3: Choose “New local workspace”
 
 ![New Workspace](/images/guide-local-workspace/new-workspace.webp)
 
-### Step 4 — Create a Local Workspace
+### Step 4: Create a Local Workspace
 
 Requestly will ask you for:
 
@@ -70,7 +70,7 @@ Requestly will ask you for:
 
 ![Name Workspace](/images/guide-local-workspace/name-workspace.png)
 
-### Step 5 — Click Create
+### Step 5: Click Create
 
 That’s it. No complicated setup, no onboarding screens, no permission drama.
 
@@ -103,7 +103,7 @@ Once my Local Workspace was ready, I created a new collection to organize my API
 
 ![Creating Collection](/images/guide-local-workspace/creating-collection.gif)
 
-The collection instantly appeared as a structured file inside my Local Workspace — meaning everything exists as real source-controlled files, not just cloud data.  
+The collection instantly appeared as a structured file inside my Local Workspace, meaning everything exists as real source-controlled files, not just cloud data.  
 That felt powerful.
 
 ---
@@ -141,7 +141,7 @@ Running requests works exactly the same as the cloud version:
 
 ## 🗑 Deleting a Local Workspace (Clean-Up Step)
 
-After experimenting with different collections and requests, you might want to clean up your environment — maybe to start fresh or remove unused workspaces. Requestly makes it super simple to delete a Local Workspace safely.
+After experimenting with different collections and requests, you might want to clean up your environment, maybe to start fresh or remove unused workspaces. Requestly makes it super simple to delete a Local Workspace safely.
 
 Here’s how I deleted mine when I was done testing:
 
@@ -195,17 +195,17 @@ Instead of juggling messy exported JSON collections or cloud sync, I now have:
 - Requests stored as real readable files
 - API testing that stays with my project’s source code
 
-Honestly — if you’re a backend or full-stack dev, you should try this immediately.
+Honestly, if you’re a backend or full-stack dev, you should try this immediately.
 
 ---
 
 ## Additional Resources
 
 - [Try Requestly App](https://app.requestly.io)
-- [Documentation — Local Workspace](https://docs.requestly.com/collaboration/local-workspace)
+- [Documentation, Local Workspace](https://docs.requestly.com/collaboration/local-workspace)
 
 ---
 
 Thanks for reading!  
 If you found this helpful, share it with someone exploring API workflows.  
-— _Bhogeshwar_
+_Bhogeshwar_

--- a/http-interception/guides/community-content/variables-and-environments-in-requestly.mdx
+++ b/http-interception/guides/community-content/variables-and-environments-in-requestly.mdx
@@ -10,11 +10,11 @@ difficulty: beginner
 
 ## Introduction
 
-When I first opened Requestly Interceptor's API Client, I expected the usual — a request builder, a few tabs, maybe a scripting panel. What I didn't expect was how powerful and convenient their Variables and Environments system would be.
+When I first opened Requestly Interceptor's API Client, I expected the usual, a request builder, a few tabs, maybe a scripting panel. What I didn't expect was how powerful and convenient their Variables and Environments system would be.
 
 If you've ever switched between dev, staging, and production APIs and found yourself constantly rewriting URLs, headers, or tokens, this feature will feel like a lifesaver.
 
-While working on a recent contribution to Requestly Interceptor, I got the chance to dive deep into Variables and Environments — and it turned out to be far more powerful than I expected. So in this article, I'm breaking down everything I learned in a simple, practical way.
+While working on a recent contribution to Requestly Interceptor, I got the chance to dive deep into Variables and Environments, and it turned out to be far more powerful than I expected. So in this article, I'm breaking down everything I learned in a simple, practical way.
 
 Think of this as your shortcut to mastering variables, with practical steps and screenshots that you can apply immediately in your own setup.
 
@@ -65,7 +65,7 @@ https://{{base_url}}/users/{{user_id}}
 
 ### Step 1: Exploring Global Variables
 
-Global variables are available everywhere — across all requests and environments. They are ideal for constants or secrets that don't change frequently. I used them for things like API keys, common headers, or service base URLs.
+Global variables are available everywhere, across all requests and environments. They are ideal for constants or secrets that don't change frequently. I used them for things like API keys, common headers, or service base URLs.
 
 #### How to Create Global Variables
 
@@ -75,7 +75,7 @@ Global variables are available everywhere — across all requests and environmen
 
 ![Adding Global Variables](/images/guide-environment-and-variables/adding-global-variables.gif)
 
-The cool part? — Hovering on any `{{variable}}` in a request immediately shows the resolved value.
+The cool part?, Hovering on any `{{variable}}` in a request immediately shows the resolved value.
 
 **Example Global Variables:**
 
@@ -89,9 +89,9 @@ content_type = application/json
 
 For my testing, I used three different APIs that all support the `/users` endpoint:
 
-- **Development** — `https://jsonplaceholder.typicode.com`
-- **Staging** — `https://dummyjson.com`
-- **Production** — `https://jsonplaceholder.org`
+- **Development**, `https://jsonplaceholder.typicode.com`
+- **Staging**, `https://dummyjson.com`
+- **Production**, `https://jsonplaceholder.org`
 
 #### Setting Up Environments
 
@@ -130,7 +130,7 @@ environment = production
 
 #### Switching Between Environments
 
-Now I can fetch users from all three environments simply by switching the active environment — no URL editing needed.
+Now I can fetch users from all three environments simply by switching the active environment, no URL editing needed.
 
 1. Look for the environment dropdown (usually in the top-right)
 2. Select your desired environment (Dev, Staging, or Prod)
@@ -181,7 +181,7 @@ rq.environment.set("token", newtoken);
 
 ### Step 4: Collection & SubCollection Variables
 
-Until now, we've looked at Global, Environment, and Runtime variables. These cover most cases — but what if you want variables that belong only to a specific group of requests?
+Until now, we've looked at Global, Environment, and Runtime variables. These cover most cases, but what if you want variables that belong only to a specific group of requests?
 
 For example:
 
@@ -249,7 +249,7 @@ When Production environment is active, Requestly Interceptor will use: `https://
 
 ### Using Variables in API Requests
 
-Once you've defined variables in Requestly Interceptor — whether global, environment, collection, or subcollection — you can reference them anywhere inside your API requests. This includes:
+Once you've defined variables in Requestly Interceptor, whether global, environment, collection, or subcollection, you can reference them anywhere inside your API requests. This includes:
 
 - URLs
 - Headers
@@ -334,14 +334,14 @@ After working with Requestly Interceptor's Variables & Environments, it's clear 
 - **Collection Variables**: Organize variables by feature or service
 - **Variable Precedence**: Environment → SubCollection → Collection → Global
 
-Everything becomes cleaner, faster, and far easier to manage — whether you're a backend developer, tester, or someone who works with multiple APIs.
+Everything becomes cleaner, faster, and far easier to manage, whether you're a backend developer, tester, or someone who works with multiple APIs.
 
 Once you start using variables properly, your entire workflow becomes smoother and more organized. It's a small feature that makes a big difference, and honestly, it's hard to work without it once you get used to it.
 
 ## Additional Resources
 
 - [Try Requestly Interceptor App](https://app.requestly.io)
-- [Requestly Interceptor Documentation — Environment and Variables](https://docs.requestly.com)
+- [Requestly Interceptor Documentation, Environment and Variables](https://docs.requestly.com)
 - [JSONPlaceholder Fake REST API](https://jsonplaceholder.typicode.com)
 - [DummyJSON API](https://dummyjson.com)
 - [Join Requestly Interceptor Discord Community](https://rqst.ly/join-community)

--- a/http-interception/guides/intercepting-and-modifying-network-requests-in-web-automation-frameworks-like-selenium-and-playwright.mdx
+++ b/http-interception/guides/intercepting-and-modifying-network-requests-in-web-automation-frameworks-like-selenium-and-playwright.mdx
@@ -32,9 +32,9 @@ There are **2 main ways** to use Requestly Interceptor in an automation environm
   <a target="_blank" href="https://github.com/requestly/requestly-automation">`Learn more →`</a>
 </Tip>
 
-1. **Header Modifications** — quick, one-off rules (no API key required)
+1. **Header Modifications**, quick, one-off rules (no API key required)
 
-2. **Import Rules via API Key** — for predefined rules managed from your Requestly Interceptor account
+2. **Import Rules via API Key**, for predefined rules managed from your Requestly Interceptor account
 
 ### Header Modifications
 

--- a/http-interception/http-rules/rule-types/delay-network-requests.mdx
+++ b/http-interception/http-rules/rule-types/delay-network-requests.mdx
@@ -64,7 +64,7 @@ The **Delay Network Request** rule in Requestly Interceptor enables you to simul
     Specify the delay duration in milliseconds. For example, enter `4000` to introduce a 4-second delay.
 
     <Warning>
-      **Delay Capping** — In the browser extension, delays are capped to prevent performance issues. The maximum delay is **5000 ms** for XHR/Fetch requests and **10000 ms** for other resources (JS, CSS, images, etc.). The <a target="_blank" href="https://requestly.com/desktop">Desktop App</a> has no such restrictions.
+      **Delay Capping**, In the browser extension, delays are capped to prevent performance issues. The maximum delay is **5000 ms** for XHR/Fetch requests and **10000 ms** for other resources (JS, CSS, images, etc.). The <a target="_blank" href="https://requestly.com/desktop">Desktop App</a> has no such restrictions.
     </Warning>
 
     <img src="/images/delay-network-requests/5144a828-7638-4a87-bc32-74bd9d23f583.png" align="center" fullwidth="false" />

--- a/http-interception/http-rules/rule-types/modify-response-body.mdx
+++ b/http-interception/http-rules/rule-types/modify-response-body.mdx
@@ -143,7 +143,7 @@ Modify API Response Rules are useful in several scenarios:
 
 **Serve local files**
 
-Replace API, HTML, JS, or CSS responses with local files. Changes to the file are reflected in real-time—no need to update the rule.
+Replace API, HTML, JS, or CSS responses with local files. Changes to the file are reflected in real-time, no need to update the rule.
 
 <img src="/images/modify-response-body/0866dfe3-91e9-4592-9cdb-07bd7a030c22.png" align="center" fullwidth="false" />
 

--- a/http-interception/interceptor/browser-extension.mdx
+++ b/http-interception/interceptor/browser-extension.mdx
@@ -6,7 +6,7 @@ description: "Learn how to use Browser Extention to intercept HTTP Request and R
 visibility: "PUBLIC"
 ---
 
-**Requestly Interceptor’s browser extension** is the simplest way to intercept and modify HTTP requests and responses directly **within your browser**. It’s lightweight, easy to install, and perfect for debugging frontend issues or simulating API responses—without needing to run a local proxy or configure complex setups.
+**Requestly Interceptor’s browser extension** is the simplest way to intercept and modify HTTP requests and responses directly **within your browser**. It’s lightweight, easy to install, and perfect for debugging frontend issues or simulating API responses, without needing to run a local proxy or configure complex setups.
 
 Whether you're a frontend developer testing new **API integrations** or a QA engineer simulating error scenarios, the browser extension gives you powerful tools right in your development environment.
 

--- a/http-interception/interceptor/desktop-app/ios-devices-interception.mdx
+++ b/http-interception/interceptor/desktop-app/ios-devices-interception.mdx
@@ -19,7 +19,7 @@ When working with iOS apps, debugging HTTP requests can be challenging. Requestl
 
 Setting up HTTP interception on physical iOS devices requires configuring a proxy and CA Certificate to intercept network traffic.
 
-### Part 1 — Configure Proxy
+### Part 1: Configure Proxy
 
 <Steps>
   <Step title="Preparation">
@@ -52,7 +52,7 @@ Setting up HTTP interception on physical iOS devices requires configuring a prox
   </Step>
 </Steps>
 
-### Part 2 — Install CA Certificate
+### Part 2: Install CA Certificate
 
 <Steps>
   <Step title="Download CA Certificate">

--- a/http-interception/troubleshoot/http-rules/rule-changes-not-reflecting-in-chrome-devtools.mdx
+++ b/http-interception/troubleshoot/http-rules/rule-changes-not-reflecting-in-chrome-devtools.mdx
@@ -7,7 +7,7 @@ description: >-
   verify they’re working.
 visibility: PUBLIC
 ---
-Some rule modifications made using Requestly Interceptor may **not appear** in Chrome’s Network DevTools — even though they are **successfully applied** in the background.
+Some rule modifications made using Requestly Interceptor may **not appear** in Chrome’s Network DevTools, even though they are **successfully applied** in the background.
 
 ### Why This Happens
 


### PR DESCRIPTION
- Add Vault overview and AWS Secrets Manager pages under api-client/vault/
- Add rq.vault scripting API reference and cross-link from related rq pages
- Group Vault pages under Variables & Environments in docs.json nav
- Replace em dashes with commas/colons/periods across existing docs